### PR TITLE
Bugfix/cdlc ws detection

### DIFF
--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_AAF.sqf
@@ -79,7 +79,7 @@ if (allowDLCTanks) then {
     _lightArmed append ["I_LT_01_AT_F", "I_LT_01_cannon_F"];
 };
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _cargoTrucks = ["I_Truck_02_flatbed_lxWS", "I_Truck_02_cargo_lxWS"];
     _AA append ["I_A_Truck_02_aa_lxWS"];
 };

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Apex.sqf
@@ -73,7 +73,7 @@ private _cargoTrucks = ["O_T_Truck_02_transport_F","O_T_Truck_02_F","O_T_Truck_0
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
 	_cargoTrucks = ["O_T_Truck_02_cargo_lxWS","O_T_Truck_02_flatbed_lxWS"];
 };
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Arid.sqf
@@ -72,7 +72,7 @@ private _cargoTrucks = ["O_Truck_02_transport_F", "O_Truck_02_covered_F", "O_Tru
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _cargoTrucks = ["O_Truck_02_cargo_lxWS","O_Truck_02_flatbed_lxWS"];
 };
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Enoch.sqf
@@ -73,7 +73,7 @@ private _cargoTrucks = ["O_T_Truck_02_transport_F", "O_T_Truck_02_F", "O_T_Truck
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _cargoTrucks = ["O_T_Truck_02_cargo_lxWS","O_T_Truck_02_flatbed_lxWS"];
 };
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_CSAT_Temperate.sqf
@@ -73,7 +73,7 @@ private _cargoTrucks = ["O_T_Truck_02_transport_F", "O_T_Truck_02_F", "O_T_Truck
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _cargoTrucks = ["O_T_Truck_02_cargo_lxWS","O_T_Truck_02_flatbed_lxWS"];
 };
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_LDF.sqf
@@ -75,7 +75,7 @@ private _cargoTrucks = ["I_E_Truck_02_transport_F", "I_E_Truck_02_F"];
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _cargoTrucks = ["I_E_Truck_02_cargo_lxWS","I_E_Truck_02_flatbed_lxWS"];
 };
 ["vehiclesCargoTrucks", _cargoTrucks] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Apex.sqf
@@ -75,7 +75,7 @@ private _APCs = ["B_T_APC_Wheeled_01_cannon_F", "B_T_APC_Tracked_01_rcws_F"];   
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _APCs append ["B_T_APC_Wheeled_01_atgm_lxWS", "B_T_APC_Wheeled_01_command_lxWS"];
 };
 ["vehiclesAPCs", _APCs] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Arid.sqf
@@ -75,7 +75,7 @@ private _APCs = ["B_APC_Wheeled_01_cannon_F", "B_APC_Tracked_01_rcws_F"];       
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _APCs append ["APC_Wheeled_01_atgm_base_lxWS", "APC_Wheeled_01_command_base_lxWS"];
 };
 ["vehiclesAPCs", _APCs] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Temperate.sqf
@@ -74,7 +74,7 @@ private _APCs = ["B_T_APC_Wheeled_01_cannon_F", "B_T_APC_Tracked_01_rcws_F"];   
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _APCs append ["B_T_APC_Wheeled_01_atgm_lxWS", "B_T_APC_Wheeled_01_command_lxWS"];
 };
 ["vehiclesAPCs", _APCs] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_AI_NATO_Tropical.sqf
@@ -75,7 +75,7 @@ private _APCs = ["B_T_APC_Wheeled_01_cannon_F", "B_T_APC_Tracked_01_rcws_F"];   
 ["minefieldAPERS", ["APERSMine"]] call _fnc_saveToTemplate;
 
 //If Western Sahara DLC
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
     _APCs append ["B_T_APC_Wheeled_01_atgm_lxWS", "B_T_APC_Wheeled_01_command_lxWS"];
 };
 ["vehiclesAPCs", _APCs] call _fnc_saveToTemplate;

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Civ.sqf
@@ -120,7 +120,7 @@ if (allowDLCOrange) then {
   ];
 };
 
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
   _dlcUniforms append [
     "U_lxWS_C_Djella_01",
     "U_lxWS_C_Djella_02",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_FIA.sqf
@@ -38,7 +38,7 @@ private _staticAA = "I_static_AA_F";
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
 
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
   _vehicleAA = "I_Tura_Truck_02_aa_lxWS";
   _staticAA = "I_Tura_ZU23_lxWS";
 };
@@ -106,7 +106,7 @@ if (allowDLCExpansion) then {_dlcUniforms append [
 ];
 };
 
-if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
+if (allowDLCWS) then {_dlcUniforms append [
     "U_lxWS_ION_Casual1",
     "U_lxWS_ION_Casual2",
     "U_lxWS_ION_Casual3",

--- a/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
+++ b/A3A/addons/core/Templates/Templates/Vanilla/Vanilla_Reb_SDK.sqf
@@ -38,7 +38,7 @@ private _staticAA = "I_static_AA_F";
 ["breachingExplosivesAPC", [["DemoCharge_Remote_Mag", 1]]] call _fnc_saveToTemplate;
 ["breachingExplosivesTank", [["SatchelCharge_Remote_Mag", 1], ["DemoCharge_Remote_Mag", 2]]] call _fnc_saveToTemplate;
 
-if (allowDLCWS && A3A_hasWS) then {
+if (allowDLCWS) then {
   _vehicleAA = "I_Tura_Truck_02_aa_lxWS";
   _staticAA = "I_Tura_ZU23_lxWS";
 };
@@ -103,7 +103,7 @@ if (allowDLCEnoch) then {_dlcUniforms append [
 ];
 };
 
-if (allowDLCWS && A3A_hasWS) then {_dlcUniforms append [
+if (allowDLCWS) then {_dlcUniforms append [
     "U_lxWS_ION_Casual1",
     "U_lxWS_ION_Casual2",
     "U_lxWS_ION_Casual3",

--- a/A3A/addons/core/functions/init/fn_initVarCommon.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarCommon.sqf
@@ -103,9 +103,6 @@ A3A_hasIFA = false;			// this one is everywhere, just mark it false and remove l
 //These are handled by a script in the Templates folder to keep integrators away from critical code.
 //call A3A_fnc_detector;
 
-//WS CDLC Detection
-//A3A_hasWS = isClass (configfile >> "CfgPatches" >> "Weapons_F_lxWS");
-
 ////////////////////////////////////
 //        BUILDINGS LISTS        ///
 ////////////////////////////////////

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -256,8 +256,9 @@ Info("Setting up faction and DLC equipment flags");
 
 // Set enabled & disabled DLC/CDLC arrays for faction/equipment modification
 private _loadedDLC = getLoadedModsInfo select {
-	(_x#3 or {_x#1 isEqualTo "ws"}) and {!(_x#1 in ["A3","curator","argo","tacops"])}} apply {tolower (_x#1)
-};
+	(_x#3 or {_x#0 isEqualTo "Arma 3 Creator DLC: Western Sahara"})
+	and {!(_x#1 in ["A3","curator","argo","tacops"])}
+} apply {tolower (_x#1)};
 A3A_enabledDLC = (_saveData get "DLC") apply {tolower _x};                 // should be pre-checked against _loadedDLC
 {
 	A3A_enabledDLC insert [0, getArray (configFile/"A3A"/"Templates"/_x/"forceDLC"), true];		// add unique elements only

--- a/A3A/addons/core/functions/init/fn_initVarServer.sqf
+++ b/A3A/addons/core/functions/init/fn_initVarServer.sqf
@@ -272,7 +272,7 @@ Debug_3("DLC enabled: %1 Disabled: %2 Vanilla: %3", A3A_enabledDLC, A3A_disabled
 
 // TODO: fix all allowDLCxxx and A3A_hasxxx references in templates
 // for the moment just fudge the ones that we're using
-A3A_hasWS = "ws" in A3A_enabledDLC; allowDLCWS = A3A_hasWS;
+allowDLCWS = "ws" in A3A_enabledDLC;
 allowDLCEnoch = "enoch" in A3A_enabledDLC;
 allowDLCTanks = "tanks" in A3A_enabledDLC;
 allowDLCOrange = "orange" in A3A_enabledDLC;

--- a/A3A/addons/core/functions/init/fn_setupMonitor.sqf
+++ b/A3A/addons/core/functions/init/fn_setupMonitor.sqf
@@ -16,7 +16,10 @@ private _addonVics = "true" configClasses (configFile/"A3A"/"AddonVics");
 
 // Ignore DLC without equipment and vehicles
 // Need the true names from here, so pass it all in
-private _loadedDLC = getLoadedModsInfo select {(_x#3 or {_x#1 isEqualTo "ws"}) and {!(_x#1 in ["A3","curator","argo","tacops"])}};
+private _loadedDLC = getLoadedModsInfo select {
+	(_x#3 or {_x#0 isEqualTo "Arma 3 Creator DLC: Western Sahara"})
+	and {!(_x#1 in ["A3","curator","argo","tacops"])}
+};
 
 
 private _autoLoadTime = "autoLoadLastGame" call BIS_fnc_getParamValue;


### PR DESCRIPTION
## What type of PR is this.
1. [x] Bug
2. [ ] Change
3. [ ] Enhancement

### What have you changed and why?
Information:
- Detection of Western Sahara DLC did not work for me. Previously there was a check for a mod with modDir named "ws". In my case the modDir was "WS", possibly since I am running Linux where the filesystem is case sensitive.
I've changed this check, so the modName is used when checking for WS CDLC. Alternatively a case-insensitive comparison (== instead of isEqualToe) could be used.
- Removed A3A_hasWS as it was redundant and essentially dead code.

### Please specify which Issue this PR Resolves.
None

### Please verify the following and ensure all checks are completed.

1. [x] Have you loaded the mission in LAN host?
2. [ ] Have you loaded the mission on a dedicated server?

### Is further testing or are further changes required?
1. [x] No
2. [ ] Yes (Please provide further detail below.)

### How can the changes be tested?
Steps: 
- Set up a new game
- Check that Western Sahara can be selected in the factions tab
- Start game with WS enabled
- Check that ION uniforms are available in arsenal

********************************************************
Notes:
